### PR TITLE
MR_SHORT_NAME same as local_redislock_redis_server ?

### DIFF
--- a/classes/lock/redis_lock_factory.php
+++ b/classes/lock/redis_lock_factory.php
@@ -136,8 +136,8 @@ class redis_lock_factory implements lock_factory {
 
         $resource = $this->type . '_' . $resource;
 
-        if (!empty($CFG->MR_SHORT_NAME)) {
-            $resource = $CFG->MR_SHORT_NAME . '_' . $resource;
+        if (!empty($CFG->local_redislock_redis_server)) {
+            $CFG->local_redislock_redis_server . '_' . $resource;
         } else {
             $resource = $CFG->dbname . '_' . $resource;
         }


### PR DESCRIPTION
It seems to me $CFG->MR_SHORT_NAME is the same as $CFG->local_redislock_redis_server -- no?  I couldn't find documentation for MR_SHORT_NAME.