### PR TITLE
feat: add port & auth to redis connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
-#About
+# About
+
 Provides a Moodle lock factory class for locking with Redis. This plugin was contributed by the Blackboard Open LMS Product Development team.  Blackboard is an education technology company dedicated to bringing excellent online teaching to institutions across the globe.  We serve colleges and universities, schools and organizations by supporting the software that educators use to manage and deliver instructional content to learners in virtual classrooms.
 
-#Requirements
+# Requirements
+
 * Moodle 2.9 or greater
 * Redis
 * PHP Redis extension
 
-#Installation
-Clone the repository or download and extract the code into the local directory of your Moodle install (e.g. $CFG->wwwroot/local/redislock) and run the site's upgrade script. Set $CFG->local_redislock_redis_server with your Redis server's connection string. Set $CFG->lock_factory to '\\\\local_redislock\\\\lock\\\\redis_lock_factory' in your config file.
+# Installation
+
+Clone the repository or download and extract the code into the local directory of your Moodle install (e.g. $CFG->wwwroot/local/redislock) and run the site's upgrade script.
+Set:
+
+ - $CFG->local_redislock_redis_server
+ - $CFG->local_redislock_redis_port
+ - $CFG->local_redislock_auth
+
+with your Redis server's connection information. Set $CFG->lock_factory to '\\\\local_redislock\\\\lock\\\\redis_lock_factory' in your config file.
 

--- a/classes/lock/redis_lock_factory.php
+++ b/classes/lock/redis_lock_factory.php
@@ -296,10 +296,16 @@ class redis_lock_factory implements lock_factory {
         if (empty($CFG->local_redislock_redis_server)) {
             throw new \coding_exception('Redis connection string is not configured in $CFG->local_redislock_redis_server');
         }
+        if (empty($CFG->local_redislock_redis_port)) {
+            $CFG->local_redislock_redis_port = 6379;
+        }
 
         try {
             $redis = new \Redis();
-            $redis->connect($CFG->local_redislock_redis_server);
+            $redis->connect($CFG->local_redislock_redis_server, $CFG->local_redislock_redis_port);
+            if (!empty(($CFG->local_redislock_redis_auth))) {
+                $redis->auth($CFG->local_redislock_redis_auth);
+            }
         } catch (\RedisException $e) {
             throw new \coding_exception("RedisException caught on host {$this->get_hostname()} with message: {$e->getMessage()}");
         }


### PR DESCRIPTION
The config now has these 3 strings, _port and _auth are optional:

- $CFG->local_redislock_redis_server
- $CFG->local_redislock_redis_port
- $CFG->local_redislock_auth