### PR TITLE
Add ability to control logging via local_redislock_logging config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Provides a Moodle lock factory class for locking with Redis. This plugin was con
 #Installation
 Clone the repository or download and extract the code into the local directory of your Moodle install (e.g. $CFG->wwwroot/local/redislock) and run the site's upgrade script. Set $CFG->local_redislock_redis_server with your Redis server's connection string. Set $CFG->lock_factory to '\\\\local_redislock\\\\lock\\\\redis_lock_factory' in your config file.
 
+Use the boolean flag `$CFG->local_redislock_logging` to control whether verbose
+logging should be emitted. If not set, logging is automatically-enabled when running
+in the CLI environment with debugging enabled on `DEBUG_NORMAL` level at least.

--- a/classes/lock/redis_lock_factory.php
+++ b/classes/lock/redis_lock_factory.php
@@ -56,24 +56,30 @@ class redis_lock_factory implements lock_factory {
     protected $openlocks = [];
 
     /**
-     * @var boolean Enables logging
+     * @var boolean Should verbose logs be emitted.
      */
     protected $logging;
 
     /**
      * @param string $type The type this lock is used for (e.g. cron, cache).
      * @param \Redis|null $redis An instance of the PHPRedis extension class.
-     * @param boolean|null $logging Enables logging
+     * @param boolean|null $logging Should verbose logs be emitted.
      * @throws \coding_exception
      */
     public function __construct($type, \Redis $redis = null, $logging = null) {
+        global $CFG;
+
         $this->type = $type;
 
         if (is_null($redis)) {
             $redis = $this->bootstrap_redis();
         }
         if (is_null($logging)) {
-            $logging = (CLI_SCRIPT && debugging() && !PHPUNIT_TEST);
+            if (isset($CFG->local_redislock_logging)) {
+                $logging = (bool) $CFG->local_redislock_logging;
+            } else {
+                $logging = (CLI_SCRIPT && debugging() && !PHPUNIT_TEST);
+            }
         }
         $this->redis   = $redis;
         $this->logging = $logging;


### PR DESCRIPTION
This allows to enable or disable logging explicitly. The default behaviour is backward-compatible fallback to autodetection based on CLI mode and debugging.