### PR TITLE
Make setUp() and tearDown() signatures compatible with PHPUnit 8.5 in Moodle 3.10

### DIFF
--- a/tests/redis_lock_factory_test.php
+++ b/tests/redis_lock_factory_test.php
@@ -39,7 +39,7 @@ use local_redislock\api\shared_redis_connection;
 
 class local_redislock_redis_lock_factory_test extends \advanced_testcase {
 
-    public function setUp() {
+    public function setUp(): void {
         global $CFG;
 
         $this->resetAfterTest();
@@ -52,7 +52,7 @@ class local_redislock_redis_lock_factory_test extends \advanced_testcase {
     /**
      * @throws coding_exception
      */
-    protected function tearDown() {
+    protected function tearDown(): void {
         shared_redis_connection::get_instance()->close();
         while (!empty(shared_redis_connection::get_instance()->get_factory_count())) {
             shared_redis_connection::get_instance()->remove_factory();


### PR DESCRIPTION
This is backwards compatible with PHPUnit 7.x too.