### PR TITLE
Make retry timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Set:
   - It can also be `hostname:port` if you want to use other port different than `6379` (Default)
 * `$CFG->lock_factory` to `'\\local_redislock\\lock\\redis_lock_factory'` in your config file.
 * `$CFG->local_redislock_auth` with your Redis server's password string.
+* `$CFG->local_redislock_retry_timeout` the time in ms to sleep between attempts to claim the lock (Default: 750)
+* `$CFG->local_redislock_retry_jitter` amount of random jitter in ms to add/subtract from `$CFG->local_redislock_retry_timeout`. (Default: 250)
 
 ## Flags
 


### PR DESCRIPTION
Instead of hardcoding the sleep timeouts between 0.5 and 1 second, make these configurable using the `$CFG->local_redislock_retry_timeout` and `$CFG->local_redislock_retry_jitter` configuration variables, which
default to the currently hardcoded limits.

cc @naderman